### PR TITLE
Wip master unsafe characters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,3 +28,6 @@ PLATFORMS
 DEPENDENCIES
   pry
   rspec
+
+BUNDLED WITH
+   1.10.2

--- a/spec/fixtures/index2.html
+++ b/spec/fixtures/index2.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Movies</title>
+  </head>
+  <body>
+    <ul>
+      <li><a href="movies/the_matrix.html">The Matrix</a></li>
+      <li><a href="movies/the_lego_movie.html">The Lego Movie</a></li>
+      <li><a href="movies/robocop.html">RoboCop</a></li>
+      <li><a href="movies/the_wolf_of_wall_street.html">The Wolf of Wall Street</a></li>
+      <li><a href="movies/frozen.html">Frozen</a></li>
+      <li><a href="movies/logan%27s_run.html">Logan's Run</a></li>
+      <li><a href="movies/a_fish_called_wanda.html">A Fish Called Wanda</a></li>
+      <li><a href="movies/the_godfather.html">The Godfather</a></li>
+      <li><a href="movies/apocalypse_now.html">Apocalypse Now</a></li>
+      <li><a href="movies/the_sting.html">The Sting</a></li>
+      <li><a href="movies/temple_grandin.html">Temple Grandin</a></li>
+      <li><a href="movies/gravity.html">Gravity</a></li>
+      <li><a href="movies/empire_of_the_sun.html">Empire of the Sun</a></li>
+      <li><a href="movies/the_big_lebowski.html">The Big Lebowski</a></li>
+      <li><a href="movies/pan%27s_labyrinth.html">Pan's Labyrinth</a></li>
+      <li><a href="movies/unbreakable.html">Unbreakable</a></li>
+      <li><a href="movies/gattaca.html">Gattaca</a></li>
+      <li><a href="movies/the_dark_knight.html">The Dark Knight</a></li>
+      <li><a href="movies/donnie_darko.html">Donnie Darko</a></li>
+      <li><a href="movies/rescue_dawn.html">Rescue Dawn</a></li>
+      <li><a href="movies/the_prestige.html">The Prestige</a></li>
+      <li><a href="movies/memento.html">Memento</a></li>
+      <li><a href="movies/avatar.html">Avatar</a></li>
+      <li><a href="movies/killing_them_softly.html">Killing Them Softly</a></li>
+      <li><a href="movies/300.html">300</a></li>
+    </ul>
+  </body>
+</html>

--- a/spec/fixtures/index3.html
+++ b/spec/fixtures/index3.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Movies</title>
+  </head>
+  <body>
+    <ul>
+      <li><a href="movies/the%20matrix.html">The Matrix</a></li>
+      <li><a href="movies/the%20lego%20movie.html">The Lego Movie</a></li>
+      <li><a href="movies/robocop.html">RoboCop</a></li>
+      <li><a href="movies/the%20wolf%20of%20wall%20street.html">The Wolf of Wall Street</a></li>
+      <li><a href="movies/frozen.html">Frozen</a></li>
+      <li><a href="movies/logan%27s%20run.html">Logan's Run</a></li>
+      <li><a href="movies/a%20fish%20called%20wanda.html">A Fish Called Wanda</a></li>
+      <li><a href="movies/the%20godfather.html">The Godfather</a></li>
+      <li><a href="movies/apocalypse%20now.html">Apocalypse Now</a></li>
+      <li><a href="movies/the%20sting.html">The Sting</a></li>
+      <li><a href="movies/temple%20grandin.html">Temple Grandin</a></li>
+      <li><a href="movies/gravity.html">Gravity</a></li>
+      <li><a href="movies/empire%20of%20the%20sun.html">Empire of the Sun</a></li>
+      <li><a href="movies/the%20big%20lebowski.html">The Big Lebowski</a></li>
+      <li><a href="movies/pan%27s%20labyrinth.html">Pan's Labyrinth</a></li>
+      <li><a href="movies/unbreakable.html">Unbreakable</a></li>
+      <li><a href="movies/gattaca.html">Gattaca</a></li>
+      <li><a href="movies/the%20dark%20knight.html">The Dark Knight</a></li>
+      <li><a href="movies/donnie%20darko.html">Donnie Darko</a></li>
+      <li><a href="movies/rescue%20dawn.html">Rescue Dawn</a></li>
+      <li><a href="movies/the%20prestige.html">The Prestige</a></li>
+      <li><a href="movies/memento.html">Memento</a></li>
+      <li><a href="movies/avatar.html">Avatar</a></li>
+      <li><a href="movies/killing%20them%20softly.html">Killing Them Softly</a></li>
+      <li><a href="movies/300.html">300</a></li>
+    </ul>
+  </body>
+</html>

--- a/spec/fixtures/the_matrix2.html
+++ b/spec/fixtures/the_matrix2.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>The Matrix</title>
+  </head>
+  <body>
+    <h1>The Matrix</h1>
+    <h3>Release Date: 1999</h3>
+    <h4><em>Director: The Wachowski Brothers</em></h4>
+    <p>A computer hacker learns from mysterious rebels about the true nature of his reality and his role in the war against its controllers.</p>
+    <br />
+    <h2>Other Movies</h2>
+    <ul>
+      <li><a href="the_matrix.html">The Matrix</a></li>
+      <li><a href="the_lego_movie.html">The Lego Movie</a></li>
+      <li><a href="robocop.html">RoboCop</a></li>
+      <li><a href="the_wolf_of_wall_street.html">The Wolf of Wall Street</a></li>
+      <li><a href="frozen.html">Frozen</a></li>
+      <li><a href="logan%27s_run.html">Logan's Run</a></li>
+      <li><a href="a_fish_called_wanda.html">A Fish Called Wanda</a></li>
+      <li><a href="the_godfather.html">The Godfather</a></li>
+      <li><a href="apocalypse_now.html">Apocalypse Now</a></li>
+      <li><a href="the_sting.html">The Sting</a></li>
+      <li><a href="temple_grandin.html">Temple Grandin</a></li>
+      <li><a href="gravity.html">Gravity</a></li>
+      <li><a href="empire_of_the_sun.html">Empire of the Sun</a></li>
+      <li><a href="the_big_lebowski.html">The Big Lebowski</a></li>
+      <li><a href="pan%27s_labyrinth.html">Pan's Labyrinth</a></li>
+      <li><a href="unbreakable.html">Unbreakable</a></li>
+      <li><a href="gattaca.html">Gattaca</a></li>
+      <li><a href="the_dark_knight.html">The Dark Knight</a></li>
+      <li><a href="donnie_darko.html">Donnie Darko</a></li>
+      <li><a href="rescue_dawn.html">Rescue Dawn</a></li>
+      <li><a href="the_prestige.html">The Prestige</a></li>
+      <li><a href="memento.html">Memento</a></li>
+      <li><a href="avatar.html">Avatar</a></li>
+      <li><a href="killing_them_softly.html">Killing Them Softly</a></li>
+      <li><a href="300.html">300</a></li>
+    </ul>
+  </body>
+</html>

--- a/spec/fixtures/the_matrix3.html
+++ b/spec/fixtures/the_matrix3.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>The Matrix</title>
+  </head>
+  <body>
+    <h1>The Matrix</h1>
+    <h3>Release Date: 1999</h3>
+    <h4><em>Director: The Wachowski Brothers</em></h4>
+    <p>A computer hacker learns from mysterious rebels about the true nature of his reality and his role in the war against its controllers.</p>
+    <br />
+    <h2>Other Movies</h2>
+    <ul>
+      <li><a href="the%20matrix.html">The Matrix</a></li>
+      <li><a href="the%20lego%20movie.html">The Lego Movie</a></li>
+      <li><a href="robocop.html">RoboCop</a></li>
+      <li><a href="the%20wolf%20of%20wall%20street.html">The Wolf of Wall Street</a></li>
+      <li><a href="frozen.html">Frozen</a></li>
+      <li><a href="logan%27s%20run.html">Logan's Run</a></li>
+      <li><a href="a%20fish%20called%20wanda.html">A Fish Called Wanda</a></li>
+      <li><a href="the%20godfather.html">The Godfather</a></li>
+      <li><a href="apocalypse%20now.html">Apocalypse Now</a></li>
+      <li><a href="the%20sting.html">The Sting</a></li>
+      <li><a href="temple%20grandin.html">Temple Grandin</a></li>
+      <li><a href="gravity.html">Gravity</a></li>
+      <li><a href="empire%20of%20the%20sun.html">Empire of the Sun</a></li>
+      <li><a href="the%20big%20lebowski.html">The Big Lebowski</a></li>
+      <li><a href="pan%27s%20labyrinth.html">Pan's Labyrinth</a></li>
+      <li><a href="unbreakable.html">Unbreakable</a></li>
+      <li><a href="gattaca.html">Gattaca</a></li>
+      <li><a href="the%20dark%20knight.html">The Dark Knight</a></li>
+      <li><a href="donnie%20darko.html">Donnie Darko</a></li>
+      <li><a href="rescue%20dawn.html">Rescue Dawn</a></li>
+      <li><a href="the%20prestige.html">The Prestige</a></li>
+      <li><a href="memento.html">Memento</a></li>
+      <li><a href="avatar.html">Avatar</a></li>
+      <li><a href="killing%20them%20softly.html">Killing Them Softly</a></li>
+      <li><a href="300.html">300</a></li>
+    </ul>
+  </body>
+</html>

--- a/spec/movie_spec.rb
+++ b/spec/movie_spec.rb
@@ -97,11 +97,13 @@ describe 'Movie' do
 
   describe '#url' do
     it 'gives a url-friendly version of the title with the .html extension' do
-      expect(the_matrix.url).to eq('the_matrix.html')
+      urls = ['the_matrix.html', 'the%20matrix.html']
+      expect(urls).to include(the_matrix.url)
     end
 
     it 'makes URLs without using unsafe characters' do 
-      expect(pans_labyrinth.url).to eq('pans_labyrinth.html' || 'pan%27s_labyrinth.html' || 'pan%27s%20labyrinth.html')
+      pans_urls = ['pans_labyrinth.html','pan%27s_labyrinth.html', 'pan%27s%20labyrinth.html']
+      expect(pans_urls).to include(pans_labyrinth.url)
     end
   end
 

--- a/spec/site_generator_spec.rb
+++ b/spec/site_generator_spec.rb
@@ -52,8 +52,11 @@ describe 'SiteGenerator' do
     it 'creates index.html in the _site directory' do
       site_generator.make_index!
       comparison = File.read('spec/fixtures/index.html')
+      comparison2 = File.read('spec/fixtures/index2.html')
+      comparison3 = File.read('spec/fixtures/index3.html')
       index = File.read('_site/index.html')
-      expect(strip_heredoc(index)).to eq(strip_heredoc(comparison))
+      comp_array = [strip_heredoc(comparison),strip_heredoc(comparison2),strip_heredoc(comparison3)]
+      expect(comp_array).to include(strip_heredoc(index))
     end
 
     it 'does NOT use erb' do
@@ -74,9 +77,16 @@ describe 'SiteGenerator' do
 
     it 'makes html pages that follow a specific layout' do
       site_generator.generate_pages!
-      the_matrix = File.read('_site/movies/the_matrix.html').gsub("\n",'').gsub(' ','')
+      if File.exists?('_site/movies/the_matrix.html')
+        the_matrix = File.read('_site/movies/the_matrix.html').gsub("\n",'').gsub(' ','')
+      else
+        the_matrix = File.read('_site/movies/the%20matrix.html').gsub("\n",'').gsub(' ','')
+      end
       comparison = File.read('spec/fixtures/the_matrix.html').gsub("\n",'').gsub(' ','')
-      expect(the_matrix).to eq(comparison || comparison2 || comparison3)
+      comparison2 = File.read('spec/fixtures/the_matrix2.html').gsub("\n",'').gsub(' ','')
+      comparison3 = File.read('spec/fixtures/the_matrix3.html').gsub("\n",'').gsub(' ','')
+      comp = [comparison, comparison2, comparison3]
+      expect(comp).to include(the_matrix)
     end
 
     it 'uses the same ERB instance inside the block' do

--- a/spec/site_generator_spec.rb
+++ b/spec/site_generator_spec.rb
@@ -76,7 +76,7 @@ describe 'SiteGenerator' do
       site_generator.generate_pages!
       the_matrix = File.read('_site/movies/the_matrix.html').gsub("\n",'').gsub(' ','')
       comparison = File.read('spec/fixtures/the_matrix.html').gsub("\n",'').gsub(' ','')
-      expect(the_matrix).to eq(comparison)
+      expect(the_matrix).to eq(comparison || comparison2 || comparison3)
     end
 
     it 'uses the same ERB instance inside the block' do


### PR DESCRIPTION
Updated the tests to handle all different variations of unsafe characters replacement in URLs. This corresponds with the issue #17.

@jmburges @deniznida @ipc103 
